### PR TITLE
fix: button text contrast on room reservation

### DIFF
--- a/resources/js/pages/rooms/Show.vue
+++ b/resources/js/pages/rooms/Show.vue
@@ -72,12 +72,12 @@ const getDateString = (date: Date) => {
                     <hr class="my-6 border-t border-haven-blue/20" />
                     <div class="flex w-full content-center justify-end gap-4">
                         <button @click="showReservationModal = true">
-                            <span class="rounded-2xl bg-haven-blue p-2">
+                            <span class="rounded-2xl bg-haven-blue p-2 text-white">
                                 Reserve
                             </span>
                         </button>
                         <Link :href="route('wip')">
-                            <div class="rounded-2xl bg-haven-blue p-2">
+                            <div class="rounded-2xl bg-haven-blue p-2 text-white">
                                 <span>Notify disturbance</span>
                             </div>
                         </Link>


### PR DESCRIPTION
Improve readability of room reservation buttons by switching text to white on dark blue background.