### PR TITLE
Add Media library and Agenda management

### DIFF
--- a/app/Console/Commands/BackfillCoverImages.php
+++ b/app/Console/Commands/BackfillCoverImages.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Media;
+use App\Traits\HasCoverMedia;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillCoverImages extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:backfill-cover-images {model? : Fully-qualified model class to backfill; all HasCoverMedia models with an image_path column if omitted}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create Media rows (and link them via coverMedia) for existing image_path values, from before cover images moved onto the Media system - does not reprocess/recompress the files, just points a Media row at what is already on disk';
+
+    public function handle(): void
+    {
+        $models = $this->argument('model')
+            ? [$this->argument('model')]
+            : $this->discoverModels();
+
+        if (empty($models)) {
+            $this->warn('No HasCoverMedia models with an image_path column were found.');
+
+            return;
+        }
+
+        foreach ($models as $modelClass) {
+            $this->backfill($modelClass);
+        }
+    }
+
+    /**
+     * @return array<int, class-string<Model>>
+     */
+    protected function discoverModels(): array
+    {
+        $models = [];
+
+        foreach (File::allFiles(app_path('Models')) as $file) {
+            $class = 'App\\Models\\'.$file->getFilenameWithoutExtension();
+
+            if (! class_exists($class) || ! is_subclass_of($class, Model::class)) {
+                continue;
+            }
+
+            if (! in_array(HasCoverMedia::class, class_uses_recursive($class))) {
+                continue;
+            }
+
+            if (! Schema::hasColumn((new $class)->getTable(), 'image_path')) {
+                continue;
+            }
+
+            $models[] = $class;
+        }
+
+        return $models;
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function backfill(string $modelClass): void
+    {
+        $query = $modelClass::query()->whereNotNull('image_path');
+
+        if (in_array(SoftDeletes::class, class_uses_recursive($modelClass))) {
+            $query->withTrashed();
+        }
+
+        $created = 0;
+        $skipped = 0;
+
+        $query->each(function (Model $model) use (&$created, &$skipped) {
+            $collection = $model->getCoverMediaCollection();
+
+            if ($model->coverMedia($collection) !== null) {
+                $skipped++;
+
+                return;
+            }
+
+            $path = $model->getAttribute('image_path');
+
+            $media = Media::create([
+                'disk' => 'hetzner',
+                'path' => $path,
+                'collection' => $collection,
+                'name' => basename($path),
+                'mediable_type' => $model->getMorphClass(),
+                'mediable_id' => $model->getKey(),
+            ]);
+
+            $created++;
+
+            $this->line("  linked {$path} -> {$model->getMorphClass()}#{$model->getKey()} (Media #{$media->id})");
+        });
+
+        $this->info("{$modelClass}: created {$created}, skipped {$skipped} (already had a cover).");
+    }
+}

--- a/app/Console/Commands/BackfillMediaAttachments.php
+++ b/app/Console/Commands/BackfillMediaAttachments.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Traits\HasMediaAttachments;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\File;
+
+class BackfillMediaAttachments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:backfill-media-attachments {model? : Fully-qualified model class to backfill; all HasMediaAttachments models if omitted}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Re-link Media rows to whichever record actually embeds them, for existing rows saved before HasMediaAttachments was wired up (or after manually editing the database)';
+
+    public function handle(): void
+    {
+        $models = $this->argument('model')
+            ? [$this->argument('model')]
+            : $this->discoverModels();
+
+        if (empty($models)) {
+            $this->warn('No models using HasMediaAttachments were found.');
+
+            return;
+        }
+
+        foreach ($models as $modelClass) {
+            $this->backfill($modelClass);
+        }
+    }
+
+    /**
+     * @return array<int, class-string<Model>>
+     */
+    protected function discoverModels(): array
+    {
+        $models = [];
+
+        foreach (File::allFiles(app_path('Models')) as $file) {
+            $class = 'App\\Models\\'.$file->getFilenameWithoutExtension();
+
+            if (! class_exists($class)) {
+                continue;
+            }
+
+            if (in_array(HasMediaAttachments::class, class_uses_recursive($class))) {
+                $models[] = $class;
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    protected function backfill(string $modelClass): void
+    {
+        $query = $modelClass::query();
+
+        if (in_array(SoftDeletes::class, class_uses_recursive($modelClass))) {
+            $query->withTrashed();
+        }
+
+        $count = 0;
+
+        $query->each(function (Model $model) use (&$count) {
+            $model->syncMediaAttachments();
+            $count++;
+        });
+
+        $this->info("{$modelClass}: synced {$count} record(s).");
+    }
+}

--- a/app/Console/Commands/CleanupUnusedMedia.php
+++ b/app/Console/Commands/CleanupUnusedMedia.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Media;
+use Illuminate\Console\Command;
+
+class CleanupUnusedMedia extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:cleanup-unused-media
+        {--days=7 : Grace period in days since a Media row last changed before it is eligible for deletion}
+        {--dry-run : List what would be deleted without actually deleting anything}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete Media rows (and their underlying files) that are not linked to any record - e.g. an upload whose parent record edit was abandoned, or an image removed from rich text/a cover slot and never reused';
+
+    public function handle(): void
+    {
+        $days = (int) $this->option('days');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = Media::query()
+            ->whereNull('mediable_type')
+            ->whereNull('mediable_id')
+            ->where('updated_at', '<', now()->subDays($days));
+
+        $count = $query->count();
+
+        if ($count === 0) {
+            $this->info("No unused Media rows older than {$days} day(s).");
+
+            return;
+        }
+
+        if ($dryRun) {
+            $this->info("Would delete {$count} unused Media row(s) (dry run, nothing changed):");
+
+            $query->get()->each(fn (Media $media) => $this->line("  {$media->path} (collection: {$media->collection}, last touched {$media->updated_at})"));
+
+            return;
+        }
+
+        // Deleted one at a time (not a bulk query delete) so Media's own
+        // `deleting` hook fires per row and actually removes each file from
+        // its disk, not just the database record.
+        $query->get()->each(fn (Media $media) => $media->delete());
+
+        $this->info("Deleted {$count} unused Media row(s) older than {$days} day(s).");
+    }
+}

--- a/app/Filament/Resources/AgendaItems/AgendaItemResource.php
+++ b/app/Filament/Resources/AgendaItems/AgendaItemResource.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems;
+
+use App\Filament\Resources\AgendaItems\Pages\CreateAgendaItem;
+use App\Filament\Resources\AgendaItems\Pages\EditAgendaItem;
+use App\Filament\Resources\AgendaItems\Pages\ListAgendaItems;
+use App\Filament\Resources\AgendaItems\Pages\ViewAgendaItem;
+use App\Filament\Resources\AgendaItems\Schemas\AgendaItemForm;
+use App\Filament\Resources\AgendaItems\Schemas\AgendaItemInfolist;
+use App\Filament\Resources\AgendaItems\Tables\AgendaItemsTable;
+use App\Models\AgendaItem;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class AgendaItemResource extends Resource
+{
+    protected static ?string $model = AgendaItem::class;
+
+    protected static ?string $navigationLabel = 'Agenda Items';
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Agenda';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Ticket;
+
+    public static function form(Schema $schema): Schema
+    {
+        return AgendaItemForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return AgendaItemInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return AgendaItemsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAgendaItems::route('/'),
+            'create' => CreateAgendaItem::route('/create'),
+            'view' => ViewAgendaItem::route('/{record}'),
+            'edit' => EditAgendaItem::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Pages/CreateAgendaItem.php
+++ b/app/Filament/Resources/AgendaItems/Pages/CreateAgendaItem.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Pages;
+
+use App\Filament\Resources\AgendaItems\AgendaItemResource;
+use App\Filament\Resources\AgendaItems\Schemas\AgendaItemForm;
+use App\Filament\Support\MediaCoverPicker;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAgendaItem extends CreateRecord
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    protected ?array $pendingCoverImageData = null;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->pendingCoverImageData = $data;
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        MediaCoverPicker::sync(
+            $this->record,
+            AgendaItemForm::COVER_STATE_KEY,
+            AgendaItemForm::COVER_COLLECTION,
+            $this->pendingCoverImageData ?? [],
+        );
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Pages/EditAgendaItem.php
+++ b/app/Filament/Resources/AgendaItems/Pages/EditAgendaItem.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Pages;
+
+use App\Filament\Resources\AgendaItems\AgendaItemResource;
+use App\Filament\Resources\AgendaItems\Schemas\AgendaItemForm;
+use App\Filament\Support\MediaCoverPicker;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAgendaItem extends EditRecord
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    protected ?array $pendingCoverImageData = null;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ViewAction::make(),
+            DeleteAction::make(),
+            ForceDeleteAction::make(),
+            RestoreAction::make(),
+        ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            ...MediaCoverPicker::hydrate($this->record, AgendaItemForm::COVER_STATE_KEY, AgendaItemForm::COVER_COLLECTION),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->pendingCoverImageData = $data;
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        MediaCoverPicker::sync(
+            $this->record,
+            AgendaItemForm::COVER_STATE_KEY,
+            AgendaItemForm::COVER_COLLECTION,
+            $this->pendingCoverImageData ?? [],
+        );
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Pages/ListAgendaItems.php
+++ b/app/Filament/Resources/AgendaItems/Pages/ListAgendaItems.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Pages;
+
+use App\Filament\Resources\AgendaItems\AgendaItemResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAgendaItems extends ListRecords
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Pages/ViewAgendaItem.php
+++ b/app/Filament/Resources/AgendaItems/Pages/ViewAgendaItem.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Pages;
+
+use App\Filament\Resources\AgendaItems\AgendaItemResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAgendaItem extends ViewRecord
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Schemas/AgendaItemForm.php
+++ b/app/Filament/Resources/AgendaItems/Schemas/AgendaItemForm.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Schemas;
+
+use App\Filament\Support\MediaCoverPicker;
+use App\Filament\Support\MediaRichEditor;
+use App\Models\User;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class AgendaItemForm
+{
+    public const COVER_STATE_KEY = 'cover_image';
+
+    public const COVER_COLLECTION = 'agenda-items-cover';
+
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('title')
+                    ->required()
+                    ->columnSpanFull(),
+                Select::make('agenda_id')
+                    ->label('Agenda')
+                    ->relationship('agenda', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->placeholder('Search or create a tag...')
+                    ->createOptionForm([
+                        TextInput::make('name')
+                            ->required(),
+                        Textarea::make('description')
+                            ->required()
+                            ->rows(4)
+                            ->columnSpanFull(),
+                        Toggle::make('public')
+                            ->default(true)
+                            ->required(),
+                    ])
+                    ->required(),
+                TextInput::make('short_description')
+                    ->required()
+                    ->maxLength(255)
+                    ->columnSpanFull(),
+                MediaRichEditor::make('description', 'agenda-items')
+                    ->required()
+                    ->columnSpanFull(),
+                DateTimePicker::make('start_date')
+                    ->required(),
+                DateTimePicker::make('end_date')
+                    ->required()
+                    ->after('start_date'),
+                Select::make('user_id')
+                    ->label('Organiser')
+                    ->relationship('user', 'name')
+                    ->getOptionLabelFromRecordUsing(fn (User $record) => "{$record->name} ({$record->email})")
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+                Select::make('organisation_id')
+                    ->label('Organisation')
+                    ->relationship('organisation', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+                Section::make('Item Image')
+                    ->description('Manage the public cover image for this agenda item.')
+                    ->schema(MediaCoverPicker::formComponents(self::COVER_STATE_KEY, self::COVER_COLLECTION)),
+            ]);
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Schemas/AgendaItemInfolist.php
+++ b/app/Filament/Resources/AgendaItems/Schemas/AgendaItemInfolist.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Schemas;
+
+use App\Models\AgendaItem;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+
+class AgendaItemInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextEntry::make('title'),
+                TextEntry::make('agenda.name')
+                    ->label('Agenda')
+                    ->badge(),
+                TextEntry::make('short_description'),
+                TextEntry::make('description')
+                    ->html()
+                    ->columnSpanFull(),
+                TextEntry::make('start_date')
+                    ->dateTime(),
+                TextEntry::make('end_date')
+                    ->dateTime(),
+                ImageEntry::make('image_url')
+                    ->label('Cover Image')
+                    ->placeholder('-'),
+                TextEntry::make('user.name')
+                    ->label('Organiser'),
+                TextEntry::make('organisation.name')
+                    ->label('Organisation'),
+                TextEntry::make('deleted_at')
+                    ->dateTime()
+                    ->visible(fn (AgendaItem $record): bool => $record->trashed()),
+                TextEntry::make('created_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+                TextEntry::make('updated_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/AgendaItems/Tables/AgendaItemsTable.php
+++ b/app/Filament/Resources/AgendaItems/Tables/AgendaItemsTable.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Resources\AgendaItems\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteBulkAction;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+
+class AgendaItemsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable(),
+                TextColumn::make('agenda.name')
+                    ->label('Agenda')
+                    ->badge()
+                    ->searchable(),
+                TextColumn::make('short_description')
+                    ->limit(50)
+                    ->searchable(),
+                TextColumn::make('start_date')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('end_date')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('user.name')
+                    ->label('Organiser')
+                    ->searchable(),
+                TextColumn::make('organisation.name')
+                    ->label('Organisation')
+                    ->searchable(),
+                TextColumn::make('deleted_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('agenda_id')
+                    ->label('Agenda Tag')
+                    ->relationship('agenda', 'name')
+                    ->searchable()
+                    ->preload(),
+                TrashedFilter::make(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    ForceDeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Agendas/AgendaResource.php
+++ b/app/Filament/Resources/Agendas/AgendaResource.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Filament\Resources\Agendas;
+
+use App\Filament\Resources\Agendas\Pages\CreateAgenda;
+use App\Filament\Resources\Agendas\Pages\EditAgenda;
+use App\Filament\Resources\Agendas\Pages\ListAgendas;
+use App\Filament\Resources\Agendas\Pages\ViewAgenda;
+use App\Filament\Resources\Agendas\RelationManagers\ItemsRelationManager;
+use App\Filament\Resources\Agendas\Schemas\AgendaForm;
+use App\Filament\Resources\Agendas\Schemas\AgendaInfolist;
+use App\Filament\Resources\Agendas\Tables\AgendasTable;
+use App\Models\Agenda;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class AgendaResource extends Resource
+{
+    protected static ?string $model = Agenda::class;
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Agenda';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Calendar;
+
+    public static function form(Schema $schema): Schema
+    {
+        return AgendaForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return AgendaInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return AgendasTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            ItemsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAgendas::route('/'),
+            'create' => CreateAgenda::route('/create'),
+            'view' => ViewAgenda::route('/{record}'),
+            'edit' => EditAgenda::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Agendas/Pages/CreateAgenda.php
+++ b/app/Filament/Resources/Agendas/Pages/CreateAgenda.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Pages;
+
+use App\Filament\Resources\Agendas\AgendaResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAgenda extends CreateRecord
+{
+    protected static string $resource = AgendaResource::class;
+}

--- a/app/Filament/Resources/Agendas/Pages/EditAgenda.php
+++ b/app/Filament/Resources/Agendas/Pages/EditAgenda.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Pages;
+
+use App\Filament\Resources\Agendas\AgendaResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAgenda extends EditRecord
+{
+    protected static string $resource = AgendaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ViewAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Agendas/Pages/ListAgendas.php
+++ b/app/Filament/Resources/Agendas/Pages/ListAgendas.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Pages;
+
+use App\Filament\Resources\Agendas\AgendaResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAgendas extends ListRecords
+{
+    protected static string $resource = AgendaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Agendas/Pages/ViewAgenda.php
+++ b/app/Filament/Resources/Agendas/Pages/ViewAgenda.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Pages;
+
+use App\Filament\Resources\Agendas\AgendaResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAgenda extends ViewRecord
+{
+    protected static string $resource = AgendaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Agendas/RelationManagers/ItemsRelationManager.php
+++ b/app/Filament/Resources/Agendas/RelationManagers/ItemsRelationManager.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\RelationManagers;
+
+use App\Filament\Resources\AgendaItems\Schemas\AgendaItemForm;
+use App\Filament\Support\MediaCoverPicker;
+use App\Filament\Support\MediaRichEditor;
+use App\Models\AgendaItem;
+use App\Models\User;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\ForceDeleteBulkAction;
+use Filament\Actions\RestoreAction;
+use Filament\Actions\RestoreBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TrashedFilter;
+use Filament\Tables\Table;
+
+class ItemsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'items';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('title')
+                    ->required()
+                    ->live(onBlur: true)
+                    ->columnSpanFull(),
+                TextInput::make('short_description')
+                    ->required()
+                    ->maxLength(255)
+                    ->columnSpanFull(),
+                MediaRichEditor::make('description', 'agenda-items')
+                    ->required()
+                    ->columnSpanFull(),
+                DateTimePicker::make('start_date')
+                    ->required(),
+                DateTimePicker::make('end_date')
+                    ->required()
+                    ->after('start_date'),
+                Select::make('user_id')
+                    ->label('Organiser')
+                    ->relationship('user', 'name')
+                    ->getOptionLabelFromRecordUsing(fn (User $record) => "{$record->name} ({$record->email})")
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+                Select::make('organisation_id')
+                    ->label('Organisation')
+                    ->relationship('organisation', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+                Section::make('Item Image')
+                    ->description('Manage the public cover image for this agenda item.')
+                    ->schema(MediaCoverPicker::formComponents(AgendaItemForm::COVER_STATE_KEY, AgendaItemForm::COVER_COLLECTION)),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable(),
+                TextColumn::make('start_date')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('end_date')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('user.name')
+                    ->label('Organiser')
+                    ->searchable(),
+                TextColumn::make('organisation.name')
+                    ->label('Organisation')
+                    ->searchable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('start_date')
+            ->filters([
+                TrashedFilter::make(),
+            ])
+            ->headerActions([
+                CreateAction::make()
+                    ->after(fn (AgendaItem $record, array $data) => MediaCoverPicker::sync(
+                        $record,
+                        AgendaItemForm::COVER_STATE_KEY,
+                        AgendaItemForm::COVER_COLLECTION,
+                        $data,
+                    )),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make()
+                    // EditAction::make() already sets its own ->fillForm() default (the
+                    // record's attributesToArray()) in its setUp(); calling ->fillForm()
+                    // again *replaces* that closure rather than adding to it, so this
+                    // has to reproduce the default and merge the cover data into it,
+                    // not just return the cover data alone.
+                    ->fillForm(fn (AgendaItem $record): array => [
+                        ...$record->attributesToArray(),
+                        ...MediaCoverPicker::hydrate(
+                            $record,
+                            AgendaItemForm::COVER_STATE_KEY,
+                            AgendaItemForm::COVER_COLLECTION,
+                        ),
+                    ])
+                    ->after(fn (AgendaItem $record, array $data) => MediaCoverPicker::sync(
+                        $record,
+                        AgendaItemForm::COVER_STATE_KEY,
+                        AgendaItemForm::COVER_COLLECTION,
+                        $data,
+                    )),
+                DeleteAction::make(),
+                RestoreAction::make(),
+                ForceDeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                    ForceDeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Agendas/Schemas/AgendaForm.php
+++ b/app/Filament/Resources/Agendas/Schemas/AgendaForm.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Schemas;
+
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+
+class AgendaForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required(),
+                Textarea::make('description')
+                    ->required()
+                    ->rows(4)
+                    ->columnSpanFull(),
+                Toggle::make('public')
+                    ->label('Public')
+                    ->helperText('Publicly visible agendas are shown to all visitors. Private agendas are hidden from the public site.')
+                    ->default(true)
+                    ->required(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Agendas/Schemas/AgendaInfolist.php
+++ b/app/Filament/Resources/Agendas/Schemas/AgendaInfolist.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Schemas;
+
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+
+class AgendaInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextEntry::make('name'),
+                TextEntry::make('description')
+                    ->columnSpanFull(),
+                IconEntry::make('public')
+                    ->boolean(),
+                TextEntry::make('created_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+                TextEntry::make('updated_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Agendas/Tables/AgendasTable.php
+++ b/app/Filament/Resources/Agendas/Tables/AgendasTable.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Filament\Resources\Agendas\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+
+class AgendasTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('description')
+                    ->limit(50)
+                    ->searchable(),
+                TextColumn::make('items_count')
+                    ->label('Items')
+                    ->counts('items')
+                    ->badge(),
+                IconColumn::make('public')
+                    ->boolean(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                TernaryFilter::make('public')
+                    ->label('Visibility')
+                    ->placeholder('All')
+                    ->trueLabel('Public only')
+                    ->falseLabel('Private only'),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Media/Actions/RenameMediaAction.php
+++ b/app/Filament/Resources/Media/Actions/RenameMediaAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Resources\Media\Actions;
+
+use App\Models\Media;
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+use Filament\Support\Icons\Heroicon;
+
+/**
+ * A lightweight rename-only action (not a full edit form) - Media names are
+ * mainly there so the "choose existing" library picker has something more
+ * searchable than an original filename like IMG_2481.jpg to show/filter by.
+ */
+class RenameMediaAction
+{
+    public static function make(): Action
+    {
+        return Action::make('rename')
+            ->label('Rename')
+            ->icon(Heroicon::Pencil)
+            ->schema([
+                TextInput::make('name')
+                    ->label('Name')
+                    ->required()
+                    ->maxLength(255),
+            ])
+            ->fillForm(fn (Media $record): array => ['name' => $record->name])
+            ->action(function (Media $record, array $data): void {
+                $record->update(['name' => $data['name']]);
+            });
+    }
+}

--- a/app/Filament/Resources/Media/MediaResource.php
+++ b/app/Filament/Resources/Media/MediaResource.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Filament\Resources\Media;
+
+use App\Filament\Resources\Media\Pages\ListMedia;
+use App\Filament\Resources\Media\Pages\ViewMedia;
+use App\Filament\Resources\Media\Schemas\MediaInfolist;
+use App\Filament\Resources\Media\Tables\MediaTable;
+use App\Models\Media;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class MediaResource extends Resource
+{
+    protected static ?string $model = Media::class;
+
+    protected static ?string $navigationLabel = 'Media Library';
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Setup';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::Photo;
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return MediaInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return MediaTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListMedia::route('/'),
+            'view' => ViewMedia::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Media/Pages/ListMedia.php
+++ b/app/Filament/Resources/Media/Pages/ListMedia.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Media\Pages;
+
+use App\Filament\Resources\Media\MediaResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMedia extends ListRecords
+{
+    protected static string $resource = MediaResource::class;
+}

--- a/app/Filament/Resources/Media/Pages/ViewMedia.php
+++ b/app/Filament/Resources/Media/Pages/ViewMedia.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\Media\Pages;
+
+use App\Filament\Resources\Media\Actions\RenameMediaAction;
+use App\Filament\Resources\Media\MediaResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMedia extends ViewRecord
+{
+    protected static string $resource = MediaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            RenameMediaAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Media/Schemas/MediaInfolist.php
+++ b/app/Filament/Resources/Media/Schemas/MediaInfolist.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Filament\Resources\Media\Schemas;
+
+use App\Models\Media;
+use Filament\Infolists\Components\ImageEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Number;
+
+class MediaInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                ImageEntry::make('url')
+                    ->label('Preview')
+                    ->columnSpanFull(),
+                TextEntry::make('api_url')
+                    ->label('API URL')
+                    ->state(fn (Media $record): string => route('api.v1.media.show', ['media' => $record]))
+                    ->copyable()
+                    ->copyMessage('Copied!'),
+                TextEntry::make('name')
+                    ->placeholder('-'),
+                TextEntry::make('collection')
+                    ->badge()
+                    ->placeholder('-'),
+                TextEntry::make('mime_type')
+                    ->label('Type')
+                    ->placeholder('-'),
+                TextEntry::make('size')
+                    ->formatStateUsing(fn (?int $state): string => $state === null ? '-' : Number::fileSize($state)),
+                TextEntry::make('mediable_type')
+                    ->label('Used By')
+                    ->formatStateUsing(fn (?string $state): string => $state ? class_basename($state) : '-'),
+                TextEntry::make('mediable_id')
+                    ->label('Used By ID')
+                    ->placeholder('-'),
+                TextEntry::make('created_at')
+                    ->dateTime(),
+                TextEntry::make('updated_at')
+                    ->dateTime(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Media/Tables/MediaTable.php
+++ b/app/Filament/Resources/Media/Tables/MediaTable.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Resources\Media\Tables;
+
+use App\Filament\Resources\Media\Actions\RenameMediaAction;
+use App\Models\Media;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Number;
+
+class MediaTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ImageColumn::make('url')
+                    ->label('Preview')
+                    ->square(),
+                TextColumn::make('name')
+                    ->placeholder('-')
+                    ->searchable(),
+                TextColumn::make('collection')
+                    ->badge()
+                    ->placeholder('-')
+                    ->searchable(),
+                TextColumn::make('mime_type')
+                    ->label('Type')
+                    ->placeholder('-'),
+                TextColumn::make('size')
+                    ->formatStateUsing(fn (?int $state): string => $state === null ? '-' : Number::fileSize($state))
+                    ->sortable(),
+                TextColumn::make('mediable_type')
+                    ->label('Used By')
+                    ->formatStateUsing(fn (?string $state): string => $state ? class_basename($state) : '-'),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('collection')
+                    ->options(fn () => Media::query()
+                        ->whereNotNull('collection')
+                        ->distinct()
+                        ->pluck('collection', 'collection')
+                        ->all()),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                RenameMediaAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Rooms/Pages/CreateRoom.php
+++ b/app/Filament/Resources/Rooms/Pages/CreateRoom.php
@@ -3,9 +3,30 @@
 namespace App\Filament\Resources\Rooms\Pages;
 
 use App\Filament\Resources\Rooms\RoomResource;
+use App\Filament\Resources\Rooms\Schemas\RoomForm;
+use App\Filament\Support\MediaCoverPicker;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateRoom extends CreateRecord
 {
     protected static string $resource = RoomResource::class;
+
+    protected ?array $pendingCoverImageData = null;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->pendingCoverImageData = $data;
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        MediaCoverPicker::sync(
+            $this->record,
+            RoomForm::COVER_STATE_KEY,
+            RoomForm::COVER_COLLECTION,
+            $this->pendingCoverImageData ?? [],
+        );
+    }
 }

--- a/app/Filament/Resources/Rooms/Pages/EditRoom.php
+++ b/app/Filament/Resources/Rooms/Pages/EditRoom.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Resources\Rooms\Pages;
 
 use App\Filament\Resources\Rooms\RoomResource;
+use App\Filament\Resources\Rooms\Schemas\RoomForm;
+use App\Filament\Support\MediaCoverPicker;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
@@ -11,11 +13,38 @@ class EditRoom extends EditRecord
 {
     protected static string $resource = RoomResource::class;
 
+    protected ?array $pendingCoverImageData = null;
+
     protected function getHeaderActions(): array
     {
         return [
             ViewAction::make(),
             DeleteAction::make(),
         ];
+    }
+
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            ...MediaCoverPicker::hydrate($this->record, RoomForm::COVER_STATE_KEY, RoomForm::COVER_COLLECTION),
+        ];
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->pendingCoverImageData = $data;
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        MediaCoverPicker::sync(
+            $this->record,
+            RoomForm::COVER_STATE_KEY,
+            RoomForm::COVER_COLLECTION,
+            $this->pendingCoverImageData ?? [],
+        );
     }
 }

--- a/app/Filament/Resources/Rooms/Schemas/RoomForm.php
+++ b/app/Filament/Resources/Rooms/Schemas/RoomForm.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\Rooms\Schemas;
 
 use App\Enums\RoomStatus;
-use Filament\Forms\Components\FileUpload;
+use App\Filament\Support\MediaCoverPicker;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Schemas\Components\Section;
@@ -11,6 +11,10 @@ use Filament\Schemas\Schema;
 
 class RoomForm
 {
+    public const COVER_STATE_KEY = 'cover_image';
+
+    public const COVER_COLLECTION = 'rooms-cover';
+
     public static function configure(Schema $schema): Schema
     {
         return $schema
@@ -37,17 +41,12 @@ class RoomForm
                     ->required(),
                 Section::make('Room Media Management')
                     ->description('Manage the public cover image and internal exit instructions.')
-                    ->schema([
-                        FileUpload::make('image_path')
-                            ->label('Main Room Preview (Single)')
-                            ->disk('hetzner')
-                            ->directory('rooms/covers')
-                            ->image()
-                            ->imageAspectRatio('3:2')
-                            ->automaticallyCropImagesToAspectRatio()
-                            ->automaticallyResizeImagesToWidth('1200')
-                            ->required(),
-                    ]),
+                    ->schema(MediaCoverPicker::formComponents(
+                        self::COVER_STATE_KEY,
+                        self::COVER_COLLECTION,
+                        'Main Room Preview (Single)',
+                        required: true,
+                    )),
             ]);
     }
 }

--- a/app/Filament/Support/MediaCoverPicker.php
+++ b/app/Filament/Support/MediaCoverPicker.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Filament\Support;
+
+use App\Models\Media;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Number;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+/**
+ * A cover-image picker that lets the user either upload a new image (run
+ * through Media::createFromUploadedFile - same resize/compress pipeline as
+ * everywhere else) or search the existing Media library and reuse a file
+ * already on disk, instead of always uploading a fresh copy.
+ *
+ * Both controls share one virtual form field, toggled by visibility. Its
+ * value is always a Media *path* string (not a UUID) - that's the one
+ * representation FileUpload understands natively for previewing an already-
+ * chosen image via ->disk(), so hydrating the field with an existing cover's
+ * path "just works" without a custom preview.
+ *
+ * The model using this must expose `coverMedia(string $collection): ?Media`
+ * (see HasCoverMedia). Call hydrate() from the resource's
+ * mutateFormDataBeforeFill() and sync() from an afterSave/afterCreate hook
+ * (or a RelationManager action's ->after()).
+ */
+class MediaCoverPicker
+{
+    /**
+     * @return array<int, Component>
+     */
+    public static function formComponents(
+        string $statePath,
+        string $collection,
+        string $label = 'Cover Image',
+        bool $required = false,
+    ): array {
+        $toggleKey = "{$statePath}_use_existing";
+
+        return [
+            Toggle::make($toggleKey)
+                ->label('Choose from existing library instead of uploading')
+                ->live()
+                ->dehydrated(false)
+                ->default(false)
+                ->afterStateUpdated(fn (callable $set) => $set($statePath, null)),
+
+            FileUpload::make($statePath)
+                ->label($label)
+                ->disk('hetzner')
+                ->directory("media/{$collection}")
+                ->visibility('private')
+                ->image()
+                ->imageAspectRatio('3:2')
+                ->automaticallyCropImagesToAspectRatio()
+                ->saveUploadedFileUsing(
+                    fn (TemporaryUploadedFile $file) => Media::createFromUploadedFile($file, $collection)->path
+                )
+                ->required($required)
+                ->visible(fn (Get $get): bool => ! $get($toggleKey))
+                ->dehydrated(fn (Get $get): bool => ! $get($toggleKey)),
+
+            Select::make($statePath)
+                ->label('Choose Existing Image')
+                ->searchable()
+                ->getSearchResultsUsing(fn (string $search): array => self::searchResults($search))
+                ->getOptionLabelUsing(fn ($value): ?string => self::labelForPath($value))
+                ->required($required)
+                ->visible(fn (Get $get): bool => (bool) $get($toggleKey))
+                ->dehydrated(fn (Get $get): bool => (bool) $get($toggleKey)),
+        ];
+    }
+
+    /**
+     * Merge into mutateFormDataBeforeFill()'s return value so the field
+     * starts populated with whatever the record's current cover already is.
+     *
+     * @return array<string, mixed>
+     */
+    public static function hydrate(?Model $record, string $statePath, string $collection): array
+    {
+        if (! $record || ! method_exists($record, 'coverMedia')) {
+            return [$statePath => null];
+        }
+
+        return [$statePath => $record->coverMedia($collection)?->path];
+    }
+
+    /**
+     * Call after the record is saved (afterCreate/afterSave, or an Action's
+     * ->after()) with the raw submitted form data. Links whichever Media the
+     * field points to as this record's cover for the collection, and
+     * releases whatever was previously linked if it changed. Leaving the
+     * field untouched (still whatever hydrate() set it to) is a no-op.
+     */
+    public static function sync(Model $record, string $statePath, string $collection, array $data): void
+    {
+        $path = $data[$statePath] ?? null;
+
+        $current = $record->coverMedia($collection);
+
+        if ($current && $current->path === $path) {
+            return;
+        }
+
+        if ($current) {
+            $current->update(['mediable_type' => null, 'mediable_id' => null]);
+        }
+
+        if ($path === null) {
+            return;
+        }
+
+        Media::query()
+            ->where('path', $path)
+            ->update([
+                'mediable_type' => $record->getMorphClass(),
+                'mediable_id' => $record->getKey(),
+            ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function searchResults(string $search): array
+    {
+        return Media::query()
+            ->where(fn ($query) => $query
+                ->where('name', 'like', "%{$search}%")
+                ->orWhere('collection', 'like', "%{$search}%"))
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get()
+            ->mapWithKeys(fn (Media $media): array => [$media->path => self::label($media)])
+            ->all();
+    }
+
+    protected static function labelForPath(?string $path): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+
+        $media = Media::query()->where('path', $path)->first();
+
+        return $media ? self::label($media) : null;
+    }
+
+    protected static function label(Media $media): string
+    {
+        $name = $media->name ?: 'Untitled';
+        $size = $media->size ? Number::fileSize($media->size) : '?';
+
+        return "{$name} · {$media->collection} · {$size}";
+    }
+}

--- a/app/Filament/Support/MediaRichEditor.php
+++ b/app/Filament/Support/MediaRichEditor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Support;
+
+use App\Models\Media;
+use Filament\Forms\Components\RichEditor;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+/**
+ * A RichEditor preconfigured to store embedded images as Media records on
+ * the private `hetzner` disk, addressed by a stable `/api/v1/media/{uuid}`
+ * URL rather than a baked-in signed URL. Filament persists whatever
+ * `saveUploadedFileAttachmentUsing` returns straight into the saved content,
+ * so the URL that ends up in the database never expires - resolving the
+ * UUID to a fresh signed URL happens at request time, in MediaShowController.
+ */
+class MediaRichEditor
+{
+    public static function make(string $name, string $collection): RichEditor
+    {
+        return RichEditor::make($name)
+            ->fileAttachmentsDisk('hetzner')
+            ->fileAttachmentsDirectory("media/{$collection}")
+            ->fileAttachmentsVisibility('private')
+            ->saveUploadedFileAttachmentUsing(
+                fn (TemporaryUploadedFile $file) => Media::createFromUploadedFile($file, $collection)->uuid
+            )
+            ->getFileAttachmentUrlUsing(fn (string $file): string => route('api.v1.media.show', ['media' => $file]));
+    }
+}

--- a/app/Http/Controllers/Api/Media/MediaShowController.php
+++ b/app/Http/Controllers/Api/Media/MediaShowController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api\Media;
+
+use App\Models\Media;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * View a media file
+ *
+ * Resolve a media file's stable UUID to a freshly-signed URL on its
+ * underlying (private) disk and redirect to it. Lets stored content (e.g.
+ * rich text) reference media by a permanent URL that never expires, since
+ * the real signed URL is only ever generated at request time.
+ *
+ * @param  Media  $media
+ * @return RedirectResponse
+ */
+class MediaShowController
+{
+    #[Group('Media')]
+    public function __invoke(Media $media): RedirectResponse
+    {
+        $url = $media->temporaryUrl();
+
+        abort_if($url === null, Response::HTTP_NOT_FOUND);
+
+        return redirect()->away($url);
+    }
+}

--- a/app/Http/Controllers/Auth/KeycloakAdminController.php
+++ b/app/Http/Controllers/Auth/KeycloakAdminController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Exception;
 use Filament\Facades\Filament;
-use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Facades\Socialite;
 use Spatie\Permission\Models\Role;
 
@@ -35,13 +34,13 @@ class KeycloakAdminController extends Controller
 
         $keycloakRoles = $keycloakUser->getRaw()['groups'] ?? [];
 
-        if (!(empty($keycloakRoles))) {
+        if (! (empty($keycloakRoles))) {
             $cleanedRoles = [];
             foreach ($keycloakRoles as $groupPath) {
                 $roleName = trim(str_replace('/', '-', $groupPath), '-');
                 Role::firstOrCreate([
                     'name' => $roleName,
-                    'guard_name' => 'web'
+                    'guard_name' => 'web',
                 ]);
 
                 $cleanedRoles[] = $roleName;
@@ -50,7 +49,6 @@ class KeycloakAdminController extends Controller
         } else {
             $user->syncRoles([]);
         }
-
 
         Filament::auth()->login($user);
 

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -2,7 +2,8 @@
 
 namespace App\Models;
 
-use App\Traits\HasS3Image;
+use App\Traits\HasCoverMedia;
+use App\Traits\HasMediaAttachments;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -11,7 +12,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class AgendaItem extends Model
 {
-    use HasS3Image, HasSlug, softDeletes;
+    use HasCoverMedia, HasMediaAttachments, HasSlug, softDeletes;
 
     public $timestamps = true;
 
@@ -27,6 +28,18 @@ class AgendaItem extends Model
         'organisation_id',
         'agenda_id',
     ];
+
+    /**
+     * Rich-text columns scanned by HasMediaAttachments to keep Media.mediable_*
+     * pointed at whichever record actually embeds each file.
+     */
+    protected array $mediaAttachmentColumns = ['description'];
+
+    /**
+     * Media collection name for this model's cover image - see HasCoverMedia
+     * and MediaCoverPicker.
+     */
+    protected string $coverMediaCollection = 'agenda-items-cover';
 
     protected $appends = ['image_url'];
 

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Intervention\Image\Encoders\AutoEncoder;
+use Intervention\Image\Laravel\Facades\Image;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Throwable;
+
+class Media extends Model
+{
+    /**
+     * Images are capped to this on their longest edge and re-encoded at
+     * reduced quality on upload - no reason to store (and ship on every
+     * view) a 4K+ photo for what's usually rendered a fraction of that size.
+     */
+    public const MAX_DIMENSION = 2000;
+
+    public const QUALITY = 82;
+
+    protected $table = 'media';
+
+    protected $fillable = [
+        'uuid',
+        'disk',
+        'path',
+        'collection',
+        'name',
+        'mime_type',
+        'size',
+        'mediable_type',
+        'mediable_id',
+    ];
+
+    protected $appends = ['url'];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Media $media) {
+            $media->uuid ??= (string) Str::uuid();
+        });
+
+        static::deleting(function (Media $media) {
+            $media->deleteFromDisk();
+            $media->clearTemporaryUrlCache();
+        });
+    }
+
+    /**
+     * Resize/compress an uploaded file and store it as a new Media record.
+     * Shared by every upload path (rich-text attachments, cover images, ...)
+     * so they all get identical treatment.
+     *
+     * Deliberately reads via $file->get() (a single GetObject) rather than
+     * $file->getSize()/getMimeType()/getRealPath() - when the Livewire temp
+     * upload disk is S3-backed, those each trigger a HeadObject call that
+     * has proven unreliable. Everything else is derived from the encoded
+     * result instead, with no further network round-trips.
+     */
+    public static function createFromUploadedFile(
+        TemporaryUploadedFile $file,
+        string $collection,
+        string $disk = 'hetzner',
+        ?int $maxDimension = null,
+        ?int $quality = null,
+    ): self {
+        $encoded = Image::read($file->get())
+            ->scaleDown(width: $maxDimension ?? self::MAX_DIMENSION, height: $maxDimension ?? self::MAX_DIMENSION)
+            ->encode(new AutoEncoder(quality: $quality ?? self::QUALITY));
+
+        $path = "media/{$collection}/".Str::uuid().'.'.self::extensionForMediaType($encoded->mediaType());
+
+        Storage::disk($disk)->put($path, (string) $encoded);
+
+        return self::create([
+            'disk' => $disk,
+            'path' => $path,
+            'collection' => $collection,
+            'name' => $file->getClientOriginalName(),
+            'mime_type' => $encoded->mediaType(),
+            'size' => $encoded->size(),
+        ]);
+    }
+
+    protected static function extensionForMediaType(string $mediaType): string
+    {
+        return match ($mediaType) {
+            'image/jpeg' => 'jpg',
+            'image/png' => 'png',
+            'image/gif' => 'gif',
+            'image/webp' => 'webp',
+            'image/avif' => 'avif',
+            'image/bmp' => 'bmp',
+            'image/tiff' => 'tiff',
+            default => 'bin',
+        };
+    }
+
+    protected function url(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->temporaryUrl(),
+        );
+    }
+
+    /**
+     * Remove the underlying file from its disk. Safe to call even if it's
+     * already gone (e.g. deleted out-of-band).
+     */
+    public function deleteFromDisk(): void
+    {
+        try {
+            $disk = Storage::disk($this->disk);
+
+            if ($disk->exists($this->path)) {
+                $disk->delete($this->path);
+            }
+        } catch (Throwable $e) {
+            logger()->error('Media deleteFromDisk error: '.$e->getMessage());
+        }
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'uuid';
+    }
+
+    public function mediable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function clearTemporaryUrlCache(): void
+    {
+        Cache::forget("media_url:{$this->uuid}");
+    }
+
+    /**
+     * Resolve a short-lived, signed URL for this file. Cached just under the
+     * signed URL's own expiry so repeated views don't re-sign on every request.
+     */
+    public function temporaryUrl(int $minutes = 15): ?string
+    {
+        $cacheKey = "media_url:{$this->uuid}";
+        $cacheSeconds = ($minutes > 2 ? $minutes - 2 : $minutes) * 60;
+
+        return Cache::remember($cacheKey, $cacheSeconds, function () use ($minutes) {
+            $disk = Storage::disk($this->disk);
+
+            try {
+                if (! $disk->exists($this->path)) {
+                    return null;
+                }
+
+                return $disk->temporaryUrl($this->path, Carbon::now()->addMinutes($minutes));
+            } catch (Throwable $e) {
+                logger()->error('Media temporaryUrl error: '.$e->getMessage());
+
+                return null;
+            }
+        });
+    }
+}

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use App\Enums\RoomStatus;
-use App\Traits\HasS3Image;
+use App\Traits\HasCoverMedia;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -15,7 +15,7 @@ use Spatie\Sluggable\SlugOptions;
  */
 class Room extends Model
 {
-    use HasS3Image, HasSlug;
+    use HasCoverMedia, HasSlug;
 
     protected $fillable = [
         'name',
@@ -29,6 +29,12 @@ class Room extends Model
     protected $casts = [
         'status' => RoomStatus::class,
     ];
+
+    /**
+     * Media collection name for this model's cover image - see HasCoverMedia
+     * and MediaCoverPicker.
+     */
+    protected string $coverMediaCollection = 'rooms-cover';
 
     protected $appends = ['image_url'];
 

--- a/app/Policies/AgendaItemPolicy.php
+++ b/app/Policies/AgendaItemPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\AgendaItem;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class AgendaItemPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:AgendaItem');
+    }
+
+    public function view(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('View:AgendaItem');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:AgendaItem');
+    }
+
+    public function update(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('Update:AgendaItem');
+    }
+
+    public function delete(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('Delete:AgendaItem');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:AgendaItem');
+    }
+
+    public function restore(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('Restore:AgendaItem');
+    }
+
+    public function forceDelete(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('ForceDelete:AgendaItem');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:AgendaItem');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:AgendaItem');
+    }
+
+    public function replicate(AuthUser $authUser, AgendaItem $agendaItem): bool
+    {
+        return $authUser->can('Replicate:AgendaItem');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:AgendaItem');
+    }
+}

--- a/app/Policies/AgendaPolicy.php
+++ b/app/Policies/AgendaPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Agenda;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class AgendaPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Agenda');
+    }
+
+    public function view(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('View:Agenda');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Agenda');
+    }
+
+    public function update(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('Update:Agenda');
+    }
+
+    public function delete(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('Delete:Agenda');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Agenda');
+    }
+
+    public function restore(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('Restore:Agenda');
+    }
+
+    public function forceDelete(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('ForceDelete:Agenda');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:Agenda');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:Agenda');
+    }
+
+    public function replicate(AuthUser $authUser, Agenda $agenda): bool
+    {
+        return $authUser->can('Replicate:Agenda');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:Agenda');
+    }
+}

--- a/app/Policies/MediaPolicy.php
+++ b/app/Policies/MediaPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Media;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class MediaPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Media');
+    }
+
+    public function view(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('View:Media');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Media');
+    }
+
+    public function update(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('Update:Media');
+    }
+
+    public function delete(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('Delete:Media');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Media');
+    }
+
+    public function restore(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('Restore:Media');
+    }
+
+    public function forceDelete(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('ForceDelete:Media');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:Media');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:Media');
+    }
+
+    public function replicate(AuthUser $authUser, Media $media): bool
+    {
+        return $authUser->can('Replicate:Media');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:Media');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -70,6 +70,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->navigationGroups([
                 'Reservation',
+                'Agenda',
                 __('filament-shield::filament-shield.nav.group'),
                 'Setup',
 

--- a/app/Traits/HasCoverMedia.php
+++ b/app/Traits/HasCoverMedia.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Media;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+/**
+ * A model's "cover image" is just a Media row whose mediable_* points back
+ * at it, disambiguated from any other Media a model might accumulate (e.g.
+ * rich-text attachments) by collection name. There's no FK column for it -
+ * MediaCoverPicker reads/writes this relationship directly via the model's
+ * morph class + key, the same way HasMediaAttachments already does for
+ * rich-text columns.
+ */
+trait HasCoverMedia
+{
+    public function coverMedia(?string $collection = null): ?Media
+    {
+        return Media::query()
+            ->where('mediable_type', $this->getMorphClass())
+            ->where('mediable_id', $this->getKey())
+            ->where('collection', $collection ?? $this->getCoverMediaCollection())
+            ->first();
+    }
+
+    public function getCoverMediaCollection(): string
+    {
+        return $this->coverMediaCollection ?? $this->getTable().'-cover';
+    }
+
+    protected function imageUrl(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->coverMedia()?->url,
+        );
+    }
+}

--- a/app/Traits/HasMediaAttachments.php
+++ b/app/Traits/HasMediaAttachments.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Media;
+
+/**
+ * Keeps Media.mediable_type/mediable_id in sync with whichever record's
+ * rich-text column(s) actually embed each file.
+ *
+ * MediaRichEditor bakes a stable `/api/v1/media/{uuid}` URL into saved
+ * content at upload time, but the parent record doesn't exist yet on a
+ * create page - so the association can only be made after the model is
+ * actually saved. This trait does that: on every save it re-scans the
+ * configured rich-text columns, claims any newly-referenced Media rows, and
+ * releases ones that were removed from the content (they become unowned
+ * again rather than being deleted, since removing a paragraph shouldn't
+ * silently delete a file - see `deleteMediaAttachments()` for the one case
+ * where outright deletion is correct: a true force-delete of the record).
+ */
+trait HasMediaAttachments
+{
+    protected static function bootHasMediaAttachments(): void
+    {
+        static::saved(function ($model) {
+            $model->syncMediaAttachments();
+        });
+
+        static::deleted(function ($model) {
+            if (method_exists($model, 'isForceDeleting') && ! $model->isForceDeleting()) {
+                return;
+            }
+
+            $model->deleteMediaAttachments();
+        });
+    }
+
+    /**
+     * Column names on this model containing rich-text content that may
+     * embed Media attachments. Defaults to the model's $mediaAttachmentColumns
+     * property; override this method for anything more dynamic.
+     */
+    public function getMediaAttachmentColumns(): array
+    {
+        return $this->mediaAttachmentColumns ?? [];
+    }
+
+    /**
+     * Link every Media file currently referenced in this model's rich-text
+     * columns to this record, and release any that no longer are.
+     */
+    public function syncMediaAttachments(): void
+    {
+        $columns = $this->getMediaAttachmentColumns();
+
+        if (empty($columns)) {
+            return;
+        }
+
+        $uuids = collect($columns)
+            ->flatMap(fn (string $column) => static::extractMediaUuids((string) $this->getAttribute($column)))
+            ->unique()
+            ->values();
+
+        if ($uuids->isNotEmpty()) {
+            Media::query()
+                ->whereIn('uuid', $uuids)
+                ->update([
+                    'mediable_type' => $this->getMorphClass(),
+                    'mediable_id' => $this->getKey(),
+                ]);
+        }
+
+        Media::query()
+            ->where('mediable_type', $this->getMorphClass())
+            ->where('mediable_id', $this->getKey())
+            ->when($uuids->isNotEmpty(), fn ($query) => $query->whereNotIn('uuid', $uuids))
+            ->update(['mediable_type' => null, 'mediable_id' => null]);
+    }
+
+    /**
+     * Permanently delete every Media attachment still linked to this record,
+     * including the underlying files. Only ever called on a true force-delete.
+     */
+    public function deleteMediaAttachments(): void
+    {
+        Media::query()
+            ->where('mediable_type', $this->getMorphClass())
+            ->where('mediable_id', $this->getKey())
+            ->get()
+            ->each->delete();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function extractMediaUuids(string $content): array
+    {
+        preg_match_all(
+            '#/api/v1/media/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})#',
+            $content,
+            $matches,
+        );
+
+        return $matches[1] ?? [];
+    }
+}

--- a/database/factories/PermissionFactory.php
+++ b/database/factories/PermissionFactory.php
@@ -2,10 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Permission;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Permission>
+ * @extends Factory<Permission>
  */
 class PermissionFactory extends Factory
 {

--- a/database/migrations/2026_08_05_160000_create_media_table.php
+++ b/database/migrations/2026_08_05_160000_create_media_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->string('disk');
+            $table->string('path');
+            $table->string('collection')->nullable();
+            $table->string('name')->nullable();
+            $table->string('mime_type')->nullable();
+            $table->unsignedBigInteger('size')->nullable();
+            $table->nullableMorphs('mediable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class PermissionSeeder extends Seeder

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\Agenda\AgendaIndexController;
+use App\Http\Controllers\Api\Media\MediaShowController;
 use App\Http\Controllers\Api\Reservation\ReservationCancelController;
 use App\Http\Controllers\Api\Reservation\ReservationStoreController;
 use App\Http\Controllers\Api\Reservation\ReservationUpdateController;
@@ -26,6 +27,9 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
 
     // Agendas
     Route::get('/agendas', AgendaIndexController::class)->name('agendas.index');
+
+    // Media
+    Route::get('/media/{media:uuid}', MediaShowController::class)->name('media.show');
 });
 
 Route::prefix('v1')->name('api.v1.')->middleware([ValidateKeycloakToken::class])->group(function () {

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,10 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('app:cleanup-unused-media')->daily();


### PR DESCRIPTION
## Summary
- Add a private, S3-backed Media library with signed-redirect serving
- Wire Media into rich-text and cover-image uploads, auto-linked to their owner
- Add Filament interface for Agendas, with Agenda Items as taggable content
- Migrate Room's cover image onto the Media library
- Add media maintenance commands: backfill existing images, cleanup unused ones