### PR TITLE
Add application-wide audit logging

### DIFF
--- a/app/Filament/Concerns/LogsRecordView.php
+++ b/app/Filament/Concerns/LogsRecordView.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Concerns;
+
+/**
+ * Drop onto a Filament ViewRecord page to record an audit-log entry each
+ * time an admin opens a record's view page. Logged under the same default
+ * log used by model CRUD (see App\Traits\Auditable), so a record's full
+ * history - created/updated/deleted/viewed - shows up in one timeline.
+ */
+trait LogsRecordView
+{
+    public function mount(int|string $record): void
+    {
+        parent::mount($record);
+
+        activity()
+            ->performedOn($this->getRecord())
+            ->event('viewed')
+            ->withProperties(['ip' => request()->ip()])
+            ->log('viewed');
+    }
+}

--- a/app/Filament/Resources/ActivityLogs/ActivityLogResource.php
+++ b/app/Filament/Resources/ActivityLogs/ActivityLogResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources\ActivityLogs;
+
+use App\Filament\Resources\ActivityLogs\Pages\ListActivityLogs;
+use App\Filament\Resources\ActivityLogs\Pages\ViewActivityLog;
+use App\Filament\Resources\ActivityLogs\Schemas\ActivityLogInfolist;
+use App\Filament\Resources\ActivityLogs\Tables\ActivityLogsTable;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Read-only view onto the audit trail (app/Traits/Auditable.php + auth
+ * events, see AppServiceProvider). No create/edit page and no delete
+ * action - the log is meant to stay an immutable record; old entries are
+ * pruned by `activitylog:clean` per config/activitylog.php instead.
+ */
+class ActivityLogResource extends Resource
+{
+    protected static ?string $model = Activity::class;
+
+    protected static ?string $navigationLabel = 'Activity Log';
+
+    protected static string|null|\UnitEnum $navigationGroup = 'Setup';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::ClipboardDocumentList;
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return ActivityLogInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return ActivityLogsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListActivityLogs::route('/'),
+            'view' => ViewActivityLog::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ActivityLogs/Pages/ListActivityLogs.php
+++ b/app/Filament/Resources/ActivityLogs/Pages/ListActivityLogs.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ActivityLogs\Pages;
+
+use App\Filament\Resources\ActivityLogs\ActivityLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListActivityLogs extends ListRecords
+{
+    protected static string $resource = ActivityLogResource::class;
+}

--- a/app/Filament/Resources/ActivityLogs/Pages/ViewActivityLog.php
+++ b/app/Filament/Resources/ActivityLogs/Pages/ViewActivityLog.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Resources\ActivityLogs\Pages;
+
+use App\Filament\Resources\ActivityLogs\ActivityLogResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewActivityLog extends ViewRecord
+{
+    protected static string $resource = ActivityLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Filament/Resources/ActivityLogs/Schemas/ActivityLogInfolist.php
+++ b/app/Filament/Resources/ActivityLogs/Schemas/ActivityLogInfolist.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Resources\ActivityLogs\Schemas;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityLogInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextEntry::make('description'),
+                TextEntry::make('event')
+                    ->badge()
+                    ->placeholder('-'),
+                TextEntry::make('log_name')
+                    ->label('Log')
+                    ->badge()
+                    ->color('gray'),
+                TextEntry::make('causer.name')
+                    ->label('By')
+                    ->placeholder('System'),
+                TextEntry::make('subject_type')
+                    ->label('Subject')
+                    ->formatStateUsing(fn (?string $state): string => $state ? class_basename($state) : '-'),
+                TextEntry::make('subject_id')
+                    ->label('Subject ID')
+                    ->placeholder('-'),
+                TextEntry::make('created_at')
+                    ->label('When')
+                    ->dateTime(),
+                TextEntry::make('attribute_changes')
+                    ->label('Changes')
+                    ->formatStateUsing(fn (Activity $record): string => '<pre class="fi-in-text text-xs whitespace-pre-wrap">'
+                        .e(json_encode($record->attribute_changes, JSON_PRETTY_PRINT))
+                        .'</pre>')
+                    ->html()
+                    ->visible(fn (Activity $record): bool => filled($record->attribute_changes))
+                    ->columnSpanFull(),
+                TextEntry::make('properties')
+                    ->formatStateUsing(fn (Activity $record): string => '<pre class="fi-in-text text-xs whitespace-pre-wrap">'
+                        .e(json_encode($record->properties, JSON_PRETTY_PRINT))
+                        .'</pre>')
+                    ->html()
+                    ->visible(fn (Activity $record): bool => filled($record->properties))
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/ActivityLogs/Tables/ActivityLogsTable.php
+++ b/app/Filament/Resources/ActivityLogs/Tables/ActivityLogsTable.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Resources\ActivityLogs\Tables;
+
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Spatie\Activitylog\Models\Activity;
+
+class ActivityLogsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('created_at')
+                    ->label('When')
+                    ->dateTime()
+                    ->sortable()
+                    ->since(),
+                TextColumn::make('causer.name')
+                    ->label('By')
+                    ->placeholder('System')
+                    ->searchable(),
+                TextColumn::make('description')
+                    ->searchable(),
+                TextColumn::make('event')
+                    ->badge()
+                    ->placeholder('-'),
+                TextColumn::make('subject_type')
+                    ->label('Subject')
+                    ->formatStateUsing(fn (?string $state): string => $state ? class_basename($state) : '-'),
+                TextColumn::make('subject_id')
+                    ->label('Subject ID')
+                    ->placeholder('-'),
+                TextColumn::make('log_name')
+                    ->label('Log')
+                    ->badge()
+                    ->color('gray'),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                SelectFilter::make('log_name')
+                    ->label('Log')
+                    ->options(fn () => Activity::query()
+                        ->whereNotNull('log_name')
+                        ->distinct()
+                        ->pluck('log_name', 'log_name')
+                        ->all()),
+                SelectFilter::make('event')
+                    ->options(fn () => Activity::query()
+                        ->whereNotNull('event')
+                        ->distinct()
+                        ->pluck('event', 'event')
+                        ->all()),
+                SelectFilter::make('subject_type')
+                    ->label('Subject')
+                    ->options(fn () => Activity::query()
+                        ->whereNotNull('subject_type')
+                        ->distinct()
+                        ->pluck('subject_type')
+                        ->mapWithKeys(fn (string $fqcn): array => [$fqcn => class_basename($fqcn)])
+                        ->all()),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->toolbarActions([
+                //
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/Pages/ViewUser.php
+++ b/app/Filament/Resources/Users/Pages/ViewUser.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Resources\Users\Pages;
 
+use App\Filament\Concerns\LogsRecordView;
 use App\Filament\Resources\Users\UserResource;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewUser extends ViewRecord
 {
+    use LogsRecordView;
+
     protected static string $resource = UserResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Http/Controllers/Auth/KeycloakAdminController.php
+++ b/app/Http/Controllers/Auth/KeycloakAdminController.php
@@ -21,6 +21,11 @@ class KeycloakAdminController extends Controller
         try {
             $keycloakUser = Socialite::driver('keycloak')->user();
         } catch (Exception $e) {
+            activity('auth')
+                ->event('login_failed')
+                ->withProperties(['ip' => request()->ip()])
+                ->log('Keycloak authentication failed');
+
             return redirect()->route('filament.admin.auth.login')->with('error', 'Keycloak authentication failed.');
         }
 

--- a/app/Listeners/LogAuthenticationEvents.php
+++ b/app/Listeners/LogAuthenticationEvents.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+
+/**
+ * Records successful logins/logouts to the activity log. Registered against
+ * Laravel's built-in Login/Logout events (see AppServiceProvider) rather
+ * than hooked into KeycloakAdminController directly, so it fires no matter
+ * which guard/flow authenticates the user. Failed Keycloak logins are
+ * logged separately in KeycloakAdminController, since a failed attempt
+ * never reaches these events (there's no authenticated user to attach).
+ */
+class LogAuthenticationEvents
+{
+    public function handleLogin(Login $event): void
+    {
+        activity('auth')
+            ->causedBy($event->user)
+            ->event('login')
+            ->withProperties(['guard' => $event->guard, 'ip' => request()->ip()])
+            ->log('User logged in');
+    }
+
+    public function handleLogout(Logout $event): void
+    {
+        if (! $event->user) {
+            return;
+        }
+
+        activity('auth')
+            ->causedBy($event->user)
+            ->event('logout')
+            ->withProperties(['guard' => $event->guard, 'ip' => request()->ip()])
+            ->log('User logged out');
+    }
+}

--- a/app/Models/Agenda.php
+++ b/app/Models/Agenda.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Sluggable\HasSlug;
@@ -9,7 +10,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class Agenda extends Model
 {
-    use HasSlug;
+    use Auditable, HasSlug;
 
     public $fillable = [
         'name',

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use App\Traits\HasCoverMedia;
 use App\Traits\HasMediaAttachments;
 use Illuminate\Database\Eloquent\Model;
@@ -12,7 +13,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class AgendaItem extends Model
 {
-    use HasCoverMedia, HasMediaAttachments, HasSlug, softDeletes;
+    use Auditable, HasCoverMedia, HasMediaAttachments, HasSlug, softDeletes;
 
     public $timestamps = true;
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Group extends Model
 {
-    use HasFactory;
+    use Auditable, HasFactory;
 
     protected $fillable = ['name'];
 

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -17,6 +18,8 @@ use Throwable;
 
 class Media extends Model
 {
+    use Auditable;
+
     /**
      * Images are capped to this on their longest edge and re-encoded at
      * reduced quality on upload - no reason to store (and ship on every

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -2,9 +2,10 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Model;
 
 class News extends Model
 {
-    //
+    use Auditable;
 }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use App\Traits\HasS3Image;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -10,7 +11,7 @@ use Spatie\Sluggable\SlugOptions;
 
 class Organisation extends Model
 {
-    use HasS3Image, HasSlug;
+    use Auditable, HasS3Image, HasSlug;
 
     protected $fillable = [
         'name',

--- a/app/Models/RegistrationCode.php
+++ b/app/Models/RegistrationCode.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Database\Factories\RegistrationCodeFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class RegistrationCode extends Model
 {
     /** @use HasFactory<RegistrationCodeFactory> */
-    use HasFactory;
+    use Auditable, HasFactory;
 
     protected $fillable = [
         'unit_id',

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\ReservationStatus;
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -10,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Reservation extends Model
 {
-    use HasFactory;
+    use Auditable, HasFactory;
 
     protected $fillable = [
         'name',

--- a/app/Models/ReservationPolicy.php
+++ b/app/Models/ReservationPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -10,6 +11,8 @@ use Spatie\Permission\Models\Role;
 
 class ReservationPolicy extends Model
 {
+    use Auditable;
+
     protected $fillable = [
         'role_name',
         'max_days_in_advance',

--- a/app/Models/ReservationPolicyEntry.php
+++ b/app/Models/ReservationPolicyEntry.php
@@ -3,11 +3,14 @@
 namespace App\Models;
 
 use App\Casts\MinutesToTime;
+use App\Traits\Auditable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReservationPolicyEntry extends Model
 {
+    use Auditable;
+
     protected $fillable = [
         'reservation_policy_id',
         'day_of_week',

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\RoomStatus;
+use App\Traits\Auditable;
 use App\Traits\HasCoverMedia;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -15,7 +16,7 @@ use Spatie\Sluggable\SlugOptions;
  */
 class Room extends Model
 {
-    use HasCoverMedia, HasSlug;
+    use Auditable, HasCoverMedia, HasSlug;
 
     protected $fillable = [
         'name',

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Database\Factories\UnitFactory;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Unit extends Model
 {
     /** @use HasFactory<UnitFactory> */
-    use HasFactory;
+    use Auditable, HasFactory;
 
     protected $fillable = [
         'building',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Auditable;
 use Carbon\Traits\Timestamp;
 use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
@@ -17,7 +18,7 @@ use Spatie\Permission\Traits\HasRoles;
 class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, HasRoles, Notifiable, Timestamp;
+    use Auditable, HasFactory, HasRoles, Notifiable, Timestamp;
 
     /**
      * The attributes that are mass assignable.
@@ -72,5 +73,14 @@ class User extends Authenticatable implements FilamentUser
     {
         // TODO: Implement canAccessPanel() method.
         return true;
+    }
+
+    /**
+     * Keep Keycloak tokens and the remember token out of the audit trail -
+     * they're secrets, not the kind of change history an audit log is for.
+     */
+    protected function auditExcept(): array
+    {
+        return [...parent::auditExcept(), 'remember_token', 'keycloak_token', 'keycloak_refresh_token'];
     }
 }

--- a/app/Policies/ActivityPolicy.php
+++ b/app/Policies/ActivityPolicy.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Registered manually against Spatie's Activity model in AppServiceProvider,
+ * since it lives outside App\Models and Laravel's convention-based policy
+ * discovery can't find it. Read-only on purpose - the audit trail isn't
+ * meant to be editable or deletable from the admin panel.
+ */
+class ActivityPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Activity');
+    }
+
+    public function view(AuthUser $authUser, Activity $activity): bool
+    {
+        return $authUser->can('View:Activity');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,10 +2,13 @@
 
 namespace App\Providers;
 
+use App\Policies\ActivityPolicy;
 use App\Providers\auth\KeycloakProvider;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use SocialiteProviders\Manager\SocialiteWasCalled;
+use Spatie\Activitylog\Models\Activity;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -22,5 +25,13 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(function (SocialiteWasCalled $event) {
             $event->extendSocialite('keycloak', KeycloakProvider::class);
         });
+
+        // Login/Logout logging lives in App\Listeners\LogAuthenticationEvents -
+        // Laravel auto-discovers it from the typed event parameter, no explicit
+        // Event::listen() needed (and would double-fire it if added here).
+
+        // Activity lives in Spatie's own namespace, so Laravel's convention-based
+        // policy discovery (App\Models\X -> App\Policies\XPolicy) can't find it.
+        Gate::policy(Activity::class, ActivityPolicy::class);
     }
 }

--- a/app/Traits/Auditable.php
+++ b/app/Traits/Auditable.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Traits;
+
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
+
+/**
+ * App-wide defaults on top of Spatie's LogsActivity: every attribute is
+ * tracked, only actual changes produce a log entry, and no-op saves don't
+ * write anything. Applied to every domain model so create/update/delete is
+ * uniformly audited - see the `activity_log` table and ActivityLogResource.
+ *
+ * Models holding secrets (tokens, etc.) should override auditExcept() to
+ * keep those values out of the log rather than relying on $hidden, which
+ * only affects serialization, not what gets recorded here.
+ */
+trait Auditable
+{
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logAll()
+            ->logExcept($this->auditExcept())
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
+
+    protected function auditExcept(): array
+    {
+        return ['updated_at'];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "league/flysystem-aws-s3-v3": "^3.0",
         "sentry/sentry-laravel": "^4.20",
         "socialiteproviders/keycloak": "^5.3",
+        "spatie/laravel-activitylog": "^5.0",
         "spatie/laravel-permission": "^7.4",
         "spatie/laravel-sluggable": "^3.7",
         "tightenco/ziggy": "^2.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da28fab963e32fd348a9b62054aee068",
+    "content-hash": "f9fe655d0c958bd27da4338e771261b7",
     "packages": [
         {
             "name": "althinect/filament-spatie-roles-permissions",
@@ -7103,6 +7103,99 @@
                 }
             ],
             "time": "2024-05-17T09:06:10+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^12.0 || ^13.0",
+                "illuminate/database": "^12.0 || ^13.0",
+                "illuminate/support": "^12.0 || ^13.0",
+                "php": "^8.4",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.29",
+                "orchestra/testbench": "^10.0 || ^11.0",
+                "pestphp/pest": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-25T10:04:54+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,0 +1,73 @@
+<?php
+
+use Spatie\Activitylog\Actions\CleanActivityLogAction;
+use Spatie\Activitylog\Actions\LogActivityAction;
+use Spatie\Activitylog\Models\Activity;
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITYLOG_ENABLED', true),
+
+    /*
+     * When the clean command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'clean_after_days' => 365,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'default',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject relationship on activities
+     * will include soft deleted models.
+     */
+    'include_soft_deleted_subjects' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => Activity::class,
+
+    /*
+     * These attributes will be excluded from logging for all models.
+     * Model-specific exclusions via logExcept() are merged with these.
+     */
+    'default_except_attributes' => [],
+
+    /*
+     * When enabled, activities are buffered in memory and inserted in a
+     * single bulk query after the response has been sent to the client.
+     * This can significantly reduce the number of database queries when
+     * many activities are logged during a single request.
+     *
+     * Only enable this if your application logs a high volume of activities
+     * per request. Buffered activities will not have an ID until the
+     * buffer is flushed.
+     */
+    'buffer' => [
+        'enabled' => env('ACTIVITYLOG_BUFFER_ENABLED', false),
+    ],
+
+    /*
+     * These action classes can be overridden to customize how activities
+     * are logged and cleaned. Your custom classes must extend the originals.
+     */
+    'actions' => [
+        'log_activity' => LogActivityAction::class,
+        'clean_log' => CleanActivityLogAction::class,
+    ],
+];

--- a/database/migrations/2026_08_07_212315_create_activity_log_table.php
+++ b/database/migrations/2026_08_07_212315_create_activity_log_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->id();
+            $table->string('log_name')->nullable()->index();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->string('event')->nullable();
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('attribute_changes')->nullable();
+            $table->json('properties')->nullable();
+            $table->timestamps();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- New `App\Traits\Auditable` trait wraps `spatie/laravel-activitylog` with app-wide defaults (log every attribute, only on real changes, skip no-op saves), applied to every domain model: `Agenda`, `AgendaItem`, `Group`, `Media`, `News`, `Organisation`, `RegistrationCode`, `Reservation`, `ReservationPolicy`, `ReservationPolicyEntry`, `Room`, `Unit`, `User`.
- `User` excludes `remember_token` and the Keycloak tokens from what gets logged.
- Logins/logouts are logged via `App\Listeners\LogAuthenticationEvents`, hooked into Laravel's built-in `Login`/`Logout` events (auto-discovered, so it fires regardless of which guard/flow authenticates). Failed Keycloak logins are logged separately in `KeycloakAdminController` since a failed attempt never produces an authenticated user to attach a `Login` event to.
- New read-only Filament resource, **Activity Log** (under Setup), to browse the trail: list + view only, no create/edit/delete — the log is meant to stay immutable, with old entries pruned via `activitylog:clean` per `config/activitylog.php` (`clean_after_days`, default 365).
- Policy: `Spatie\Activitylog\Models\Activity` lives outside `App\Models`, so its policy is registered manually (`Gate::policy(...)` in `AppServiceProvider`) rather than relying on Laravel's naming-convention discovery.

## Verified
- `php artisan migrate` runs the new `activity_log` table cleanly (Postgres, via Sail).
- Exercised create/update/delete through tinker — diffs land correctly in `attribute_changes`.
- Exercised `Login`/`Logout` events directly — confirmed no duplicate log entries after removing a redundant manual `Event::listen()` (Laravel already auto-discovers typed listener methods in `app/Listeners`).
- `ActivityLogsTable`/`ActivityLogInfolist` build without error; new routes register (`/admin/activity-logs`).
- Pint clean; existing test suite passes (only a placeholder example test currently exists in this repo).

## Follow-up (next PR)
This lands as its own PR per your call to sequence audit-log first — the upcoming Membership feature will pick up `Auditable` automatically once its models are added.

## Note
Filament's `CodeEntry` infolist component (used for syntax-highlighted JSON) is unusable in this project as-is — it hard-depends on `phiki/phiki`, which isn't installed anywhere in `composer.lock`. Went with a plain `<pre>`-based diff view instead rather than pulling in a new dependency for this. Flagging in case that's wanted elsewhere later.